### PR TITLE
Simpler alert markup

### DIFF
--- a/alerts/index.html
+++ b/alerts/index.html
@@ -6,19 +6,24 @@
       integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
       crossorigin="anonymous"
     />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css">
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css"
+    />
     <style>
+
       :root {
         --rgb-poppy: 233, 131, 0;
         --bs-warning-rgb: var(--rgb-poppy);
         --bs-warning-bg-subtle: rgba(var(--rgb-poppy), 0.1);
         --bs-warning-border-subtle: rgba(var(--rgb-poppy), 1);
-        --bs-warning-text-emphasis: black;
+        --bs-warning-text-emphasis: rgba(var(--rgb-poppy), 1);
+
         --rgb-digital-blue: 0, 84, 143;
         --bs-info-rgb: var(--rgb-digital-blue);
         --bs-info-bg-subtle: rgba(var(--rgb-digital-blue), 0.1);
         --bs-info-border-subtle: rgba(var(--rgb-digital-blue), 1);
-        --bs-info-text-emphasis: black;
+        --bs-info-text-emphasis: rgba(var(--rgb-digital-blue), 1);
       }
 
       body
@@ -30,60 +35,56 @@
     ></script>
   </head>
   <body class="p-5">
-
-<h1>Warning alert</h1>
-<div class="alert alert-warning d-flex shadow-sm" role="alert">
-    <div class="bi bi-exclamation-triangle-fill d-flex justify-content-center display-6 col-1 ms-3 align-self-center text-warning">
-    </div>
-    <div class="p-3 flex-grow-1">
-      <div class="d-flex align-items-center gap-2">
-        <div>
-          <span class="fw-semibold d-block">Warning</span>
-          Alert text
-        </div>
+    <h1 class="mb-4">Warning alert</h1>
+    <div
+      role="alert"
+      class="alert alert-warning d-flex shadow-sm align-items-center"
+    >
+      <div
+        class="bi bi-exclamation-triangle-fill display-6 me-3 align-self-center d-flex justify-content-center"
+      ></div>
+      <div class="text-body">
+        <div class="fw-semibold">Warning</div>
+        <div>Alert text</div>
       </div>
     </div>
-</div>
-<pre><code class="d-block" style="white-space: pre-wrap; ">
+
+    <pre><code class="d-block " style="white-space: pre-wrap; ">
 
 :root {
   --rgb-poppy: 233, 131, 0;
   --bs-warning-rgb: var(--rgb-poppy);
   --bs-warning-bg-subtle: rgba(var(--rgb-poppy), 0.1);
   --bs-warning-border-subtle: rgba(var(--rgb-poppy), 1);
-  --bs-warning-text-emphasis: black;
+  --bs-warning-text-emphasis: rgba(var(--rgb-poppy), 1);
 }
 
 
-&lt;div class="alert alert-warning d-flex shadow-sm" role="alert"&gt;
-    &lt;div class="bi bi-exclamation-triangle-fill d-flex justify-content-center display-6 col-1 ms-3 align-self-center text-warning"&gt;
-    &lt;/div&gt;
-    &lt;div class="p-3 flex-grow-1"&gt;
-      &lt;div class="d-flex align-items-center gap-2"&gt;
-        &lt;div&gt;
-          &lt;span class="fw-semibold d-block"&gt;Warning&lt;/span&gt;
-          Alert text
-        &lt;/div&gt;
-      &lt;/div&gt;
-    &lt;/div&gt;
+&lt;div role=&quot;alert&quot; class=&quot;alert alert-warning d-flex shadow-sm align-items-center&quot;&gt;
+  &lt;div class=&quot;bi bi-exclamation-triangle-fill display-6 me-3 align-self-center
+              d-flex justify-content-center&quot;&gt;&lt;/div&gt;
+  &lt;div class=&quot;text-body&quot;&gt;
+    &lt;div class=&quot;fw-semibold&quot;&gt;Warning&lt;/div&gt;
+    &lt;div&gt;Alert text&lt;/div&gt;
+  &lt;/div&gt;
 &lt;/div&gt;
 </code></pre>
 
-
-<h1>Info alert</h1>
-<div class="alert alert-info d-flex shadow-sm" role="alert">
-    <div class="bi bi-info-circle-fill d-flex justify-content-center display-6 col-1 ms-3 align-self-center text-info">
-    </div>
-    <div class="p-3 flex-grow-1">
-      <div class="d-flex align-items-center gap-2">
-        <div>
-          <span class="fw-semibold d-block">Note</span>
-          Info text
-        </div>
+    <h1 class="mb-4">Info alert</h1>
+    <div
+      role="alert"
+      class="alert alert-info d-flex shadow-sm align-items-center"
+    >
+      <div
+        class="bi bi-info-circle-fill display-6 me-3 align-self-center d-flex justify-content-center"
+      ></div>
+      <div class="text-body">
+        <div class="fw-semibold">Note</div>
+        <div>Info text</div>
       </div>
     </div>
-</div>
-<pre><code class="d-block" style="white-space: pre-wrap; ">
+
+    <pre><code class="d-block" style="white-space: pre-wrap; ">
 
 :root {
   --rgb-digital-blue: 0, 84, 143;
@@ -94,39 +95,39 @@
 }
 
 
-&lt;div class="alert alert-info d-flex shadow-sm" role="alert"&gt;
-    &lt;div class="bi bi-info-circle-fill d-flex justify-content-center display-6 col-1 ms-3 align-self-center text-info"&gt;
-    &lt;/div&gt;
-    &lt;div class="p-3 flex-grow-1"&gt;
-      &lt;div class="d-flex align-items-center gap-2"&gt;
-        &lt;div&gt;
-          &lt;span class="fw-semibold d-block"&gt;Note&lt;/span&gt;
-          Info text
-        &lt;/div&gt;
-      &lt;/div&gt;
-    &lt;/div&gt;
+&lt;div role=&quot;alert&quot; class=&quot;alert alert-info d-flex shadow-sm align-items-center&quot;&gt;
+  &lt;div class=&quot;bi bi-exclamation-triangle-fill display-6 me-3 align-self-center
+              d-flex justify-content-center&quot;&gt;&lt;/div&gt;
+  &lt;div class=&quot;text-body&quot;&gt;
+    &lt;div class=&quot;fw-semibold&quot;&gt;Warning&lt;/div&gt;
+    &lt;div&gt;Info text&lt;/div&gt;
+  &lt;/div&gt;
 &lt;/div&gt;
 </code></pre>
 
-<h1>Dimissable Alert</h1>
+    <h1 class="mb-4">Dimissable Alert</h1>
 
+    <div
+      class="alert alert-warning alert-dismissible shadow-sm d-flex align-items-center"
+    >
+      <i class="bi bi-exclamation-triangle-fill fs-3 me-3"></i>
+      <div class="text-body">Alert</div>
+      <button
+        type="button"
+        class="btn-close"
+        data-bs-dismiss="alert"
+        aria-label="Close"
+      ></button>
+    </div>
 
-<div class="alert alert-warning alert-dismissible shadow-sm d-flex gap-3 align-items-center mt-3">
-  <i class="bi bi-exclamation-triangle-fill fs-3 text-warning"></i>
-  <div>
-    Alert
-  </div>
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-</div>
-
-<pre><code>
-  &lt;div class="alert alert-warning alert-dismissible shadow-sm d-flex gap-3 align-items-center mt-3"&gt;
-  &lt;i class="bi bi-exclamation-triangle-fill fs-3 text-warning"&gt;&lt;/i&gt;
-  &lt;div&gt;
+    <pre><code>
+  &lt;div class="alert alert-warning alert-dismissible shadow-sm d-flex align-items-center"&gt;
+  &lt;i class="bi bi-exclamation-triangle-fill fs-3 me-3"&gt;&lt;/i&gt;
+  &lt;div class=&quot;text-body&quot;&gt;
     Alert
   &lt;/div&gt;
   &lt;button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"&gt;&lt;/button&gt;
 &lt;/div&gt;
 </code></pre>
-</body>
+  </body>
 </html>

--- a/alerts/index.html
+++ b/alerts/index.html
@@ -41,7 +41,7 @@
       class="alert alert-warning d-flex shadow-sm align-items-center"
     >
       <div
-        class="bi bi-exclamation-triangle-fill display-6 me-3 align-self-center d-flex justify-content-center"
+        class="bi bi-exclamation-triangle-fill fs-3 me-3 align-self-center d-flex justify-content-center"
       ></div>
       <div class="text-body">
         <div class="fw-semibold">Warning</div>
@@ -61,7 +61,7 @@
 
 
 &lt;div role=&quot;alert&quot; class=&quot;alert alert-warning d-flex shadow-sm align-items-center&quot;&gt;
-  &lt;div class=&quot;bi bi-exclamation-triangle-fill display-6 me-3 align-self-center
+  &lt;div class=&quot;bi bi-exclamation-triangle-fill fs-3 me-3 align-self-center
               d-flex justify-content-center&quot;&gt;&lt;/div&gt;
   &lt;div class=&quot;text-body&quot;&gt;
     &lt;div class=&quot;fw-semibold&quot;&gt;Warning&lt;/div&gt;
@@ -76,7 +76,7 @@
       class="alert alert-info d-flex shadow-sm align-items-center"
     >
       <div
-        class="bi bi-info-circle-fill display-6 me-3 align-self-center d-flex justify-content-center"
+        class="bi bi-info-circle-fill fs-3 me-3 align-self-center d-flex justify-content-center"
       ></div>
       <div class="text-body">
         <div class="fw-semibold">Note</div>
@@ -96,7 +96,7 @@
 
 
 &lt;div role=&quot;alert&quot; class=&quot;alert alert-info d-flex shadow-sm align-items-center&quot;&gt;
-  &lt;div class=&quot;bi bi-exclamation-triangle-fill display-6 me-3 align-self-center
+  &lt;div class=&quot;bi bi-exclamation-triangle-fill fs-3 me-3 align-self-center
               d-flex justify-content-center&quot;&gt;&lt;/div&gt;
   &lt;div class=&quot;text-body&quot;&gt;
     &lt;div class=&quot;fw-semibold&quot;&gt;Warning&lt;/div&gt;


### PR DESCRIPTION
This version only goes 3 nodes deep and doesn't need `p-3` or `ms-3`. 

We can set `--bs-alert-padding-y` if we need more padding.