### PR TITLE
update button padding

### DIFF
--- a/styles/button.css
+++ b/styles/button.css
@@ -3,6 +3,8 @@
   --bs-btn-disabled-bg: var(--stanford-10-black);
   --bs-btn-disabled-border-color: var(--stanford-30-black);
   --bs-btn-disabled-opacity: 1;
+  --bs-btn-padding-y: 0.25rem;
+  --bs-btn-padding-x: 0.5rem;
 }
 
 .btn:hover {


### PR DESCRIPTION
Component library defines these as smaller (screenshot). By default in bootstrap they are --bs-btn-padding-y: .375rem and --bs-btn-padding-x: .0.75rem.


![Screenshot 2024-08-30 at 5 09 42 PM](https://github.com/user-attachments/assets/23f5464b-786a-4058-bdd2-8535035f1ee9)
