### PR TITLE
Remove underline on SU footer mark hover

### DIFF
--- a/styles/footer.css
+++ b/styles/footer.css
@@ -37,17 +37,14 @@ footer a {
 }
 
 .su-logo {
+  --bs-link-hover-decoration: none;
+
   display: inline-block;
-  font-family: var(--font-family-serif);
+  font-family: Stanford, var(--font-family-serif);
   font-variant-ligatures: discretionary-ligatures;
   font-feature-settings: "liga";
   font-weight: 400;
   font-size: 2.125rem;
   line-height: 0.75;
   text-decoration: none;
-}
-
-.su-logo-university {
-  font-size: 1.5rem;
-  padding-left: 0.5rem;
 }

--- a/styles/typography.css
+++ b/styles/typography.css
@@ -1,6 +1,17 @@
 @import "https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap";
 @import "https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&display=swap";
 
+@font-face {
+  font-family: Stanford;
+  src:
+    url("https://www-media.stanford.edu/assets/fonts/stanford.woff")
+      format("woff"),
+    url("https://www-media.stanford.edu/assets/fonts/stanford.ttf")
+      format("truetype");
+  font-weight: 300;
+  font-display: swap;
+}
+
 :root {
   --font-family-serif: "Source Serif 4", serif;
   --bs-font-sans-serif: "Source Sans 3";


### PR DESCRIPTION
Also switch in the custom Stanford font so that the size/weights are consistent.

Fixes #26 