### PR TITLE
Remove redundant aria roles from semantic HTML elements

### DIFF
--- a/footer/index.html
+++ b/footer/index.html
@@ -20,7 +20,7 @@
   </head>
   <body>
     <h1 class="m-5">Footer</h1>
-    <footer role="contentinfo">
+    <footer>
       <section id="pre-footer" class="pt-3 pb-2">
         <div class="container">
           <div class="row">

--- a/header/index.html
+++ b/header/index.html
@@ -29,7 +29,7 @@
   <body>
     <h1>Headers</h1>
     <h2>With navigation links</h2>
-    <nav id="skip-link" role="navigation" aria-label="Skip links">
+    <nav id="skip-link" aria-label="Skip links">
       <a
         class="visually-hidden-focusable element-invisible element-focusable rounded-bottom py-2 px-3"
         data-turbolinks="false"
@@ -57,7 +57,6 @@
       </div>
       <nav
         class="navbar navbar-expand-md bg-dark palo-alto-dark"
-        role="navigation"
       >
         <div class="container">
           <a
@@ -252,7 +251,7 @@
     </div>
 
     <h2 class="mt-5">Without navigation links</h2>
-    <nav id="skip-link" role="navigation" aria-label="Skip links">
+    <nav id="skip-link" aria-label="Skip links">
       <!-- skip links here -->
     </nav>
     <header>
@@ -263,7 +262,6 @@
       </div>
       <nav
         class="navbar navbar-expand-md bg-dark palo-alto-dark"
-        role="navigation"
       >
         <div class="container">
           <a


### PR DESCRIPTION
Exhibits was flagged for this by SODA and I noticed we had some instances in the component library as well. See https://github.com/sul-dlss/exhibits/issues/2501