### PR TITLE
Remove margin-top in logo

### DIFF
--- a/styles/header.css
+++ b/styles/header.css
@@ -14,7 +14,7 @@
   font-variant-ligatures: discretionary-ligatures;
   font-feature-settings: "liga";
   height: 1.875em;
-  margin-top: 0.125rem;
+  padding-top: 0.125rem;
   white-space: nowrap;
 }
 /* stylelint-enable selector-class-pattern */


### PR DESCRIPTION
This adds margin above the top bar line, which becomes apparent if you make the top-bar some other color than the body bgcolor.  See https://github.com/sul-dlss/exhibits/issues/2594