### PR TITLE
Set facet card-header btn font weight for Blacklight 8

### DIFF
--- a/styles/facets.css
+++ b/styles/facets.css
@@ -42,6 +42,13 @@
 
       .btn {
         --bs-btn-font-size: 1.125rem;
+
+        /* TODO: setting --bs-btn-font-weight variable should work for Blacklight 9 */
+
+        /* Blacklight 8 sets font-weight on .facet-field-heading button: */
+
+        /* https://github.com/projectblacklight/blacklight/blob/8afe948ab55b980bd66c201d8f0896aedb10b8a5/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss#L6; */
+        font-weight: 400;
       }
     }
 
@@ -70,8 +77,12 @@
         background-color: var(--bs-card-cap-bg) !important;
 
         .btn {
-          --bs-btn-font-weight: 600;
+          /* TODO: setting --bs-btn-font-weight variable should work for Blacklight 9 */
 
+          /* Blacklight 8 sets font-weight on .facet-field-heading button: */
+
+          /* https://github.com/projectblacklight/blacklight/blob/8afe948ab55b980bd66c201d8f0896aedb10b8a5/app/assets/stylesheets/blacklight/_bootstrap_overrides.scss#L6; */
+          font-weight: 600;
           color: var(--bs-body-color);
         }
       }


### PR DESCRIPTION
Fixes #72 

Before:
<img width="423" alt="Screenshot 2024-12-20 at 1 26 46 PM" src="https://github.com/user-attachments/assets/93ee16bb-ffd0-44cb-84f0-9cc5362b4049" />

After:
<img width="360" alt="Screenshot 2024-12-20 at 1 26 17 PM" src="https://github.com/user-attachments/assets/259cf4ec-8c5f-4e3e-b8ce-ead288909acb" />
