### PR TITLE
Application name should always be start justified (the default bahavior)

### DIFF
--- a/header/index.html
+++ b/header/index.html
@@ -224,7 +224,7 @@
         <div class="container">
           <div class="row align-items-center">
             <div
-              class="col-md-8 d-flex justify-content-center justify-content-md-start"
+              class="col-md-8 d-flex"
             >
               <div class="h1 my-4"><a href="/">Website at Stanford</a></div>
             </div>
@@ -420,7 +420,7 @@
         <div class="container">
           <div class="row align-items-center">
             <div
-              class="col-md-8 d-flex justify-content-center justify-content-md-start"
+              class="col-md-8 d-flex"
             >
               <div class="h1 my-3"><a href="/">Website at Stanford</a></div>
             </div>


### PR DESCRIPTION
Fixes #59 

Issue says to left justify in mobile view, but I'm pretty sure that means _always_ left justify.