### PR TITLE
Set up workflow for managing preview builds on github pages

### DIFF
--- a/.github/workflows/pages-main.yml
+++ b/.github/workflows/pages-main.yml
@@ -9,10 +9,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Allow only one concurrent deployment to main.
+# Prevent race conditions between main and preview deploys by setting the same
+# concurrency group and forcing them to queue.
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # Build site and commit to gh-pages branch
@@ -23,14 +24,14 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - name: Rebase gh-pages branch
+      - name: Update gh-pages branch from main
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git fetch origin -a
           git checkout main
           git checkout gh-pages
-          git rebase origin main
+          git merge -s theirs main
       - name: Push changes
         uses: ad-m/github-push-action@v0.6.0
         with:

--- a/.github/workflows/pages-preview.yml
+++ b/.github/workflows/pages-preview.yml
@@ -1,0 +1,132 @@
+# Workflow for building and deploying PRs to preview changes on github pages
+name: pages-preview
+
+on:
+  # Runs on pull requests targeting the default branch that change HTML or CSS
+  pull_request:
+    branches: ["main"]
+    types: ["opened", "reopened", "synchronize", "closed"]
+    paths:
+      - "**/*.html"
+      - "**/*.css"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Prevent race conditions between main and preview deploys by setting the same
+# concurrency group and forcing them to queue.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  # Name of the directory where the preview will be built
+  PREVIEW_DIR: preview-${{ github.event.number }}
+  # Unique directory for this run
+  PREVIEW_RUN_DIR: preview-${{ github.event.number }}-${{ github.run_number }}
+
+jobs:
+  # If the PR is opened or reopened, create a new preview directory
+  create-preview:
+    if: github.event.action == 'opened' || github.event.action == 'reopened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Copy contents to subdirectory
+        run: |
+          echo "Copying contents to $PREVIEW_DIR"
+          mkdir $PREVIEW_DIR
+          shopt -s extglob
+          cp -r !($PREVIEW_DIR) $PREVIEW_DIR/
+      - name: Checkout gh-pages branch
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git fetch origin -a
+          git checkout gh-pages
+      - name: Commit new preview directory
+        id: create-preview
+        run: |
+          git add $PREVIEW_DIR
+          git commit -m "Add preview for PR ${{ github.event.number }}"
+          echo "preview_url=https://sul-dlss.github.io/${{ github.event.repository.name }}/$PREVIEW_DIR" >> $GITHUB_OUTPUT
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+      - name: Add PR comment with link to preview
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-success: "A preview of this branch is available at ${{ steps.create-preview.outputs.preview_url }}."
+
+  # If the PR was updated, overwrite the existing preview directory
+  sync-preview:
+    if: github.event.action == 'synchronize'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Copy contents to subdirectory
+        run: |
+          echo "Copying contents to $PREVIEW_RUN_DIR"
+          mkdir $PREVIEW_RUN_DIR
+          shopt -s extglob
+          cp -r !($PREVIEW_RUN_DIR) $PREVIEW_RUN_DIR/
+      - name: Checkout gh-pages branch
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git fetch origin -a
+          git checkout gh-pages
+      - name: Overwrite preview directory
+        id: update-preview
+        run: |
+          rm -rf $PREVIEW_DIR
+          mv $PREVIEW_RUN_DIR $PREVIEW_DIR
+      - name: Check if there were changes to commit
+        id: check-changes
+        run: |
+          if [ -z "$(git diff)" ]
+          then
+            echo "No changes to commit"
+            echo "changes=0" >> $GITHUB_OUTPUT
+          else
+            echo "Changes detected; updating preview"
+            echo "changes=1" >> $GITHUB_OUTPUT
+          fi
+      - name: Commit updated preview directory
+        if: steps.check-changes.outputs.changes > 0
+        run: |
+          git add $PREVIEW_DIR
+          git commit -m "Update preview for PR ${{ github.event.number }}"
+      - name: Push changes
+        if: steps.check-changes.outputs.changes > 0
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+
+  # If the PR was closed, remove the preview directory
+  remove-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Checkout gh-pages branch
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git fetch origin -a
+          git checkout gh-pages
+      - name: Delete preview directory
+        run: |
+          git rm -r $PREVIEW_DIR
+          git commit -m "Remove preview for PR ${{ github.event.number }}"
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/README.md
+++ b/README.md
@@ -1,16 +1,7 @@
 # DLSS design component library
 
-Reference implementation of components for DLSS
-
-- [Alert](alerts/)
-- [Button](button/)
-- [Footer](footer/)
-- [Header](header/)
-- [Links](links/)
-- [Selected Item](selected_item/)
-- [Selected Facet](selected_facet/)
-- [Toast](toast/)
-- [Facet list](facets/)
+Reference implementation of components for DLSS. A live version is hosted via
+GitHub Pages at <https://sul-dlss.github.io/component-library/>.
 
 A note about color. The primary color will always be "digital blue". A site may
 choose a secondary color like "cardinal" or "digital green".
@@ -54,6 +45,22 @@ npm run lint
 ```
 
 This also runs in CI.
+
+## Deploying
+
+The site is built and deployed to GitHub Pages automatically on every push to
+`main`, by a workflow that merges changes into the `gh-pages` branch.
+
+When PRs are opened, the `pages-preview` workflow will commit a preview of the
+site to a subdirectory on the `gh-pages` branch so that it is available to
+view on the web. The URL for the preview will be:
+
+```
+https://sul-dlss.github.io/component-library/preview-[PR-number]
+```
+
+When the PR is merged, the subdirectory will be cleaned up via another commit
+to the `gh-pages` branch.
 
 ## Releasing
 

--- a/header/index.html
+++ b/header/index.html
@@ -33,6 +33,5 @@
 
     <h2 class="mt-5">Without navigation links</h2>
     <iframe src="without_navigation_links.html" style="width: 100vw; height: 100vh"></iframe>
-
   </body>
 </html>

--- a/header/index.html
+++ b/header/index.html
@@ -33,5 +33,6 @@
 
     <h2 class="mt-5">Without navigation links</h2>
     <iframe src="without_navigation_links.html" style="width: 100vw; height: 100vh"></iframe>
+
   </body>
 </html>


### PR DESCRIPTION
This implement review branches using a strategy @dnoneill suggested.

When a PR is opened or reopened, the workflow will copy the contents of the component library on that branch into a subdir and then merge it into the `gh-pages` branch, which will cause it to be served at `https://sul-dlss.github.io/component-library/preview-[PR-number]/`.

When a PR is updated, the workflow will overwrite the contents of the existing `preview-[PR-number]` subdirectory with the latest contents.

When a PR is closed, the workflow will delete the corresponding subdirectory.

You can see it working for this PR at https://sul-dlss.github.io/component-library/preview-100/ (although there were no changes to actual components to view).