### PR TITLE
Apply changes from main to gh-pages via copying strategy

### DIFF
--- a/.github/workflows/pages-main.yml
+++ b/.github/workflows/pages-main.yml
@@ -1,4 +1,4 @@
-# Workflow for building and deploying the main branch to github pages
+# Workflow for applying changes from the main branch to github pages
 name: pages-main
 
 on:
@@ -16,22 +16,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build site and commit to gh-pages branch
-  build-commit:
+  # Add changes from main to the gh-pages branch and commit
+  update-from-main:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Update gh-pages branch from main
+      - name: Copy contents to subdirectory
+        run: |
+          echo "Copying contents to main/"
+          mkdir main
+          shopt -s extglob
+          cp -r !(main) main/
+      - name: Checkout gh-pages branch
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git fetch origin -a
-          git checkout main
           git checkout gh-pages
-          git merge main
+      - name: Commit changes from main
+        run: |
+          yes | cp -r main/ .
+          rm -rf main
+          git add .
+          git commit -m "Update from main" -m "${{ github.sha }}"
       - name: Push changes
         uses: ad-m/github-push-action@v0.6.0
         with:


### PR DESCRIPTION
This applies the same copying files strategy used in the preview
builds to main, so that the unrelated histories of the gh-pages
and main branches don't need to be reconciled.

It also adds extra info to each commit applied to gh-pages in this
way so that they can be related back to what was merged into main,
if needed.
