### PR TITLE
Add the list of component back to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@ choose a secondary color like "cardinal" or "digital green".
 
 See <https://identity.stanford.edu/design-elements/color/web/>
 
+## Components
+
+- [Alert](alerts/)
+- [Button](button/)
+- [Footer](footer/)
+- [Header](header/)
+- [Links](links/)
+- [Selected Item](selected_item/)
+- [Selected Facet](selected_facet/)
+- [Toast](toast/)
+- [Facet list](facets/)
+- [Pagination](pagination/)
+
 ## HTML head link
 
 ```html


### PR DESCRIPTION
This makes it easier to click a link and view the component
when you visit the site on GitHub pages, especially for preview
branches.

Also adds the pagination component to the list.
