### PR TITLE
Footer updates

### DIFF
--- a/footer/index.html
+++ b/footer/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
@@ -21,38 +21,36 @@
   <body>
     <h1 class="m-5">Footer</h1>
     <footer>
-      <section id="pre-footer" class="pt-3 pb-2">
+      <section id="pre-footer" class="py-3">
         <div class="container">
-          <div class="row">
+          <div class="row gap-3 gap-lg-0">
             <div
               id="sul-footer-img"
-              class="col-sm-12 col-md-5 col-lg-4 col-xl-3 d-flex justify-content-center justify-content-md-start"
+              class="col-sm-12 col-lg-4 col-xl-3 d-flex justify-content-center justify-content-lg-start"
             >
               <a href="https://library.stanford.edu" class="prefooter-logo"
                 >Stanford University Libraries</a
               >
             </div>
             <div
-              class="col d-flex justify-content-md-start justify-content-center"
+              class="col d-flex justify-content-center justify-content-lg-start align-items-center"
             >
-              <ul
-                class="list-unstyled d-flex mt-3 mt-md-1 mt-lg-3 ms-xl-3 text-center"
-              >
-                <li class="mx-2 mx-md-3">
+              <ul class="list-unstyled d-flex text-center my-0 gap-3">
+                <li>
                   <a
                     href="https://library.stanford.edu/libraries-0/branches-and-centers"
                     >Hours &amp; locations</a
                   >
                 </li>
-                <li class="mx-2 mx-md-3">
+                <li>
                   <a href="https://mylibrary.stanford.edu">My Account</a>
                 </li>
-                <li class="mx-2 mx-md-3">
+                <li>
                   <a href="https://library.stanford.edu/contact-us"
                     >Contact us</a
                   >
                 </li>
-                <li class="mx-2 mx-md-3">
+                <li>
                   <a href="https://library-status.stanford.edu/"
                     >System status</a
                   >
@@ -189,170 +187,172 @@
     <pre
       class="m-5"
     ><code class="d-block language-html" style="white-space: pre-wrap; ">
-&lt;footer role=&quot;contentinfo&quot;&gt;
-  &lt;section id=&quot;pre-footer&quot; class=&quot;pt-3 pb-2&quot;&gt;
-    &lt;div class=&quot;container&quot;&gt;
-      &lt;div class=&quot;row&quot;&gt;
+    &lt;footer&gt;
+      &lt;section id=&quot;pre-footer&quot; class=&quot;py-3&quot;&gt;
+        &lt;div class=&quot;container&quot;&gt;
+          &lt;div class=&quot;row gap-3 gap-lg-0&quot;&gt;
+            &lt;div
+              id=&quot;sul-footer-img&quot;
+              class=&quot;col-sm-12 col-lg-4 col-xl-3 d-flex justify-content-center justify-content-lg-start&quot;
+            &gt;
+              &lt;a href=&quot;https://library.stanford.edu&quot; class=&quot;prefooter-logo&quot;
+                &gt;Stanford University Libraries&lt;/a
+              &gt;
+            &lt;/div&gt;
+            &lt;div
+              class=&quot;col d-flex justify-content-center justify-content-lg-start align-items-center&quot;
+            &gt;
+              &lt;ul
+                class=&quot;list-unstyled d-flex text-center my-0 gap-3&quot;
+              &gt;
+                &lt;li&gt;
+                  &lt;a
+                    href=&quot;https://library.stanford.edu/libraries-0/branches-and-centers&quot;
+                    &gt;Hours &amp;amp; locations&lt;/a
+                  &gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a href=&quot;https://mylibrary.stanford.edu&quot;&gt;My Account&lt;/a&gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a href=&quot;https://library.stanford.edu/contact-us&quot;
+                    &gt;Contact us&lt;/a
+                  &gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a href=&quot;https://library-status.stanford.edu/&quot;
+                    &gt;System status&lt;/a
+                  &gt;
+                &lt;/li&gt;
+              &lt;/ul&gt;
+            &lt;/div&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/section&gt;
+      &lt;div id=&quot;su-footer&quot; class=&quot;text-white bg-dark pt-4 pb-4&quot;&gt;
         &lt;div
-          id=&quot;sul-footer-img&quot;
-          class=&quot;col-sm-12 col-md-5 col-lg-4 col-xl-3 d-flex justify-content-center justify-content-md-start&quot;
+          class=&quot;container d-flex flex-column flex-lg-row align-items-center align-md-normal&quot;
+          title=&quot;Common Stanford resources&quot;
         &gt;
-          &lt;a href=&quot;https://library.stanford.edu&quot; class=&quot;prefooter-logo&quot;&gt;&lt;/a&gt;
-        &lt;/div&gt;
-        &lt;div
-          class=&quot;col d-flex justify-content-md-start justify-content-center&quot;
-        &gt;
-          &lt;ul
-            class=&quot;list-unstyled d-flex mt-3 mt-md-1 mt-lg-3 ms-xl-3 text-center&quot;
-          &gt;
-            &lt;li class=&quot;mx-2 mx-md-3&quot;&gt;
-              &lt;a
-                href=&quot;https://library.stanford.edu/libraries-0/branches-and-centers&quot;
-                &gt;Hours &amp;amp; locations&lt;/a
+          &lt;div class=&quot;mt-1 mb-2 align-self-lg-start&quot;&gt;
+            &lt;a class=&quot;su-logo&quot; href=&quot;https://www.stanford.edu&quot;
+              &gt;Stanford&lt;br /&gt;&lt;span class=&quot;su-logo-university&quot;
+                &gt;University&lt;/span
+              &gt;&lt;/a
+            &gt;
+          &lt;/div&gt;
+          &lt;div class=&quot;ms-lg-5&quot;&gt;
+            &lt;nav
+              aria-label=&quot;global footer menu&quot;
+              class=&quot;d-flex flex-row gap-4 gap-sm-0 flex-sm-column justify-content-center justify-content-lg-start align-items-start align-items-sm-center align-items-lg-start&quot;
+            &gt;
+              &lt;ul
+                class=&quot;justify-content-center justify-content-lg-start fw-semibold gap-sm-2 gap-md-3 gap-lg-4 list-unstyled d-flex flex-column flex-sm-row&quot;
               &gt;
-            &lt;/li&gt;
-            &lt;li class=&quot;mx-2 mx-md-3&quot;&gt;
-              &lt;a href=&quot;https://mylibrary.stanford.edu&quot;&gt;My Account&lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li class=&quot;mx-2 mx-md-3&quot;&gt;
-              &lt;a href=&quot;https://library.stanford.edu/contact-us&quot;
-                &gt;Contact us&lt;/a
+                &lt;li&gt;
+                  &lt;a href=&quot;https://www.stanford.edu&quot;&gt;
+                    Stanford Home&lt;span class=&quot;visually-hidden&quot;
+                      &gt;(link is external)&lt;/span
+                    &gt;
+                  &lt;/a&gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a href=&quot;https://visit.stanford.edu/plan/&quot;&gt;
+                    Maps &amp;amp; Directions&lt;span class=&quot;visually-hidden&quot;
+                      &gt;(link is external)&lt;/span
+                    &gt;
+                  &lt;/a&gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a href=&quot;https://www.stanford.edu/search/&quot;&gt;
+                    Search Stanford&lt;span class=&quot;visually-hidden&quot;
+                      &gt;(link is external)&lt;/span
+                    &gt;
+                  &lt;/a&gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a href=&quot;https://emergency.stanford.edu&quot;&gt;
+                    Emergency Info&lt;span class=&quot;visually-hidden&quot;
+                      &gt;(link is external)&lt;/span
+                    &gt;
+                  &lt;/a&gt;
+                &lt;/li&gt;
+              &lt;/ul&gt;
+              &lt;ul
+                class=&quot;justify-content-center justify-content-lg-start gap-sm-2 gap-md-3 gap-lg-4 list-unstyled d-flex flex-column flex-sm-row&quot;
               &gt;
-            &lt;/li&gt;
-            &lt;li class=&quot;mx-2 mx-md-3&quot;&gt;
-              &lt;a href=&quot;https://library-status.stanford.edu/&quot;
-                &gt;System status&lt;/a
+                &lt;li&gt;
+                  &lt;a
+                    href=&quot;https://www.stanford.edu/site/terms/&quot;
+                    title=&quot;Terms of use for sites&quot;
+                  &gt;
+                    Terms of Use&lt;span class=&quot;visually-hidden&quot;
+                      &gt;(link is external)&lt;/span
+                    &gt;
+                  &lt;/a&gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a
+                    href=&quot;https://www.stanford.edu/site/privacy/&quot;
+                    title=&quot;Privacy and cookie policy&quot;
+                  &gt;
+                    Privacy&lt;span class=&quot;visually-hidden&quot;
+                      &gt;(link is external)&lt;/span
+                    &gt;
+                  &lt;/a&gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a
+                    href=&quot;https://uit.stanford.edu/security/copyright-infringement&quot;
+                    title=&quot;Report alleged copyright infringement&quot;
+                  &gt;
+                    Copyright&lt;span class=&quot;visually-hidden&quot;
+                      &gt;(link is external)&lt;/span
+                    &gt;
+                  &lt;/a&gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a
+                    href=&quot;https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4&quot;
+                    title=&quot;Ownership and use of Stanford trademarks and images&quot;
+                  &gt;
+                    Trademarks&lt;span class=&quot;visually-hidden&quot;
+                      &gt;(link is external)&lt;/span
+                    &gt;
+                  &lt;/a&gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a
+                    href=&quot;https://studentservices.stanford.edu/more-resources/student-policies/non-academic/non-discrimination&quot;
+                    title=&quot;Non-discrimination policy&quot;
+                  &gt;
+                    Non-Discrimination&lt;span class=&quot;visually-hidden&quot;
+                      &gt;(link is external)&lt;/span
+                    &gt;
+                  &lt;/a&gt;
+                &lt;/li&gt;
+                &lt;li&gt;
+                  &lt;a
+                    href=&quot;https://www.stanford.edu/site/accessibility&quot;
+                    title=&quot;Report web accessibility issues&quot;
+                  &gt;
+                    Accessibility&lt;span class=&quot;visually-hidden&quot;
+                      &gt;(link is external)&lt;/span
+                    &gt;
+                  &lt;/a&gt;
+                &lt;/li&gt;
+              &lt;/ul&gt;
+            &lt;/nav&gt;
+            &lt;div class=&quot;text-center text-lg-start copyright&quot;&gt;
+              &lt;span class=&quot;text-nowrap&quot;&gt;&copy; Stanford University.&lt;/span
+              &gt;&lt;span class=&quot;text-nowrap&quot;
+                &gt;&amp;nbsp; Stanford, California 94305.&lt;/span
               &gt;
-            &lt;/li&gt;
-          &lt;/ul&gt;
-        &lt;/div&gt;
-      &lt;/div&gt;
-    &lt;/div&gt;
-  &lt;/section&gt;
-  &lt;div id=&quot;su-footer&quot; class=&quot;text-white bg-dark pt-4 pb-4&quot;&gt;
-    &lt;div
-      class=&quot;container d-flex flex-column flex-lg-row align-items-center align-md-normal&quot;
-      title=&quot;Common Stanford resources&quot;
-    &gt;
-      &lt;div class=&quot;mt-1 mb-2 align-self-lg-start&quot;&gt;
-        &lt;a class=&quot;su-logo&quot; href=&quot;https://www.stanford.edu&quot;
-          &gt;Stanford&lt;br&gt;&lt;span class=&quot;su-logo-university&quot;
-            &gt;University&lt;/span
-          &gt;&lt;/a
-        &gt;
-      &lt;/div&gt;
-      &lt;div class=&quot;ms-lg-5&quot;&gt;
-        &lt;nav
-          aria-label=&quot;global footer menu&quot;
-          class=&quot;d-flex flex-row gap-4 gap-sm-0 flex-sm-column justify-content-center justify-content-lg-start align-items-start align-items-sm-center align-items-lg-start&quot;
-        &gt;
-          &lt;ul
-            class=&quot;justify-content-center justify-content-lg-start fw-semibold gap-sm-2 gap-md-3 gap-lg-4 list-unstyled d-flex flex-column flex-sm-row&quot;
-          &gt;
-            &lt;li&gt;
-              &lt;a href=&quot;https://www.stanford.edu&quot;&gt;
-                Stanford Home&lt;span class=&quot;visually-hidden&quot;
-                  &gt;(link is external)&lt;/span
-                &gt;
-              &lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li&gt;
-              &lt;a href=&quot;https://visit.stanford.edu/plan/&quot;&gt;
-                Maps &amp;amp; Directions&lt;span class=&quot;visually-hidden&quot;
-                  &gt;(link is external)&lt;/span
-                &gt;
-              &lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li&gt;
-              &lt;a href=&quot;https://www.stanford.edu/search/&quot;&gt;
-                Search Stanford&lt;span class=&quot;visually-hidden&quot;
-                  &gt;(link is external)&lt;/span
-                &gt;
-              &lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li&gt;
-              &lt;a href=&quot;https://emergency.stanford.edu&quot;&gt;
-                Emergency Info&lt;span class=&quot;visually-hidden&quot;
-                  &gt;(link is external)&lt;/span
-                &gt;
-              &lt;/a&gt;
-            &lt;/li&gt;
-          &lt;/ul&gt;
-          &lt;ul
-            class=&quot;justify-content-center justify-content-lg-start gap-sm-2 gap-md-3 gap-lg-4 list-unstyled d-flex flex-column flex-sm-row&quot;
-          &gt;
-            &lt;li&gt;
-              &lt;a
-                href=&quot;https://www.stanford.edu/site/terms/&quot;
-                title=&quot;Terms of use for sites&quot;
-              &gt;
-                Terms of Use&lt;span class=&quot;visually-hidden&quot;
-                  &gt;(link is external)&lt;/span
-                &gt;
-              &lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li&gt;
-              &lt;a
-                href=&quot;https://www.stanford.edu/site/privacy/&quot;
-                title=&quot;Privacy and cookie policy&quot;
-              &gt;
-                Privacy&lt;span class=&quot;visually-hidden&quot;
-                  &gt;(link is external)&lt;/span
-                &gt;
-              &lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li&gt;
-              &lt;a
-                href=&quot;https://uit.stanford.edu/security/copyright-infringement&quot;
-                title=&quot;Report alleged copyright infringement&quot;
-              &gt;
-                Copyright&lt;span class=&quot;visually-hidden&quot;
-                  &gt;(link is external)&lt;/span
-                &gt;
-              &lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li&gt;
-              &lt;a
-                href=&quot;https://adminguide.stanford.edu/chapter-1/subchapter-5/policy-1-5-4&quot;
-                title=&quot;Ownership and use of Stanford trademarks and images&quot;
-              &gt;
-                Trademarks&lt;span class=&quot;visually-hidden&quot;
-                  &gt;(link is external)&lt;/span
-                &gt;
-              &lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li&gt;
-              &lt;a
-                href=&quot;https://studentservices.stanford.edu/more-resources/student-policies/non-academic/non-discrimination&quot;
-                title=&quot;Non-discrimination policy&quot;
-              &gt;
-                Non-Discrimination&lt;span class=&quot;visually-hidden&quot;
-                  &gt;(link is external)&lt;/span
-                &gt;
-              &lt;/a&gt;
-            &lt;/li&gt;
-            &lt;li&gt;
-              &lt;a
-                href=&quot;https://www.stanford.edu/site/accessibility&quot;
-                title=&quot;Report web accessibility issues&quot;
-              &gt;
-                Accessibility&lt;span class=&quot;visually-hidden&quot;
-                  &gt;(link is external)&lt;/span
-                &gt;
-              &lt;/a&gt;
-            &lt;/li&gt;
-          &lt;/ul&gt;
-        &lt;/nav&gt;
-        &lt;div class=&quot;text-center text-lg-start copyright&quot;&gt;
-          &lt;span class=&quot;text-nowrap&quot;&gt;&copy; Stanford University.&lt;/span
-          &gt;&lt;span class=&quot;text-nowrap&quot;
-            &gt;&amp;nbsp; Stanford, California 94305.&lt;/span
-          &gt;
+            &lt;/div&gt;
+          &lt;/div&gt;
         &lt;/div&gt;
       &lt;/div&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
-&lt;/footer&gt;
+    &lt;/footer&gt;
 </code></pre>
   </body>
 </html>

--- a/styles/header.css
+++ b/styles/header.css
@@ -31,7 +31,7 @@
   overflow: hidden;
   text-indent: 100%;
   white-space: nowrap;
-  width: 280px;
+  width: 250px;
 }
 
 /* The .navbars selector is because adding .navbar to the nav in the masthead


### PR DESCRIPTION
- Use flexbox to size and align items in the prefooter
- Adjust size of SUL logo

This simplifies a bunch of styles that were using margins to
just use flex and gap, so that we don't have margins on individual
list items or differing top/bottom margins.

Also adjusts the breakpoints at which the footer changes layout
in order to more closely match the designs (as well as the SUL
footer below it).