### PR TITLE
Darken the border of the white header to black-50

### DIFF
--- a/styles/header.css
+++ b/styles/header.css
@@ -124,6 +124,8 @@
 }
 
 .masthead {
+  --bs-border-color: var(--stanford-50-black);
+
   /* No w-{breakpoint}-{value} helper, so we have to do this */
   .navbars {
     width: 100%;

--- a/styles/palette.css
+++ b/styles/palette.css
@@ -6,6 +6,7 @@
   --stanford-black-rgb: 46, 45, 41;
   --stanford-80-black: #585754;
   --stanford-70-black: #6d6c69;
+  --stanford-50-black: #979694;
   --stanford-30-black: #c0c0bf;
   --stanford-10-black: #eaeaea;
   --stanford-10-black-rgb: 234, 234, 234;


### PR DESCRIPTION
This change was suggested by Astrid via slack in order to increase
contrast between the white header and subsequent body.
