### PR TITLE
Workaround facet-limit styles in Blacklight 8

### DIFF
--- a/styles/facets.css
+++ b/styles/facets.css
@@ -63,6 +63,14 @@
       }
     }
 
+    &.facet-limit {
+      /* Only needed for BL 8. https://github.com/projectblacklight/blacklight/pull/3262 removes these styles in BL9 */
+      .btn:focus-visible {
+        outline: 2px solid var(--bs-btn-focus-box-shadow); /* Outer color */
+        box-shadow: 0 0 0 4px var(--stanford-black); /* Inner color */
+      }
+    }
+
     &.facet-limit-active {
       --bs-card-cap-bg: var(--stanford-fog-light);
 


### PR DESCRIPTION
Looking at trying to address https://github.com/sul-dlss/exhibits/issues/2861. The additional specificity of facet-limit from Blacklight 8 prevents our button styles from applying. It seems like this could be a common issue for our BL8 apps (e.g., EarthWorks also has this issue). I'm open to suggestions, I definitely don't like duplicating the button styles.