### PR TITLE
Add stanford-fog-light-rgb

### DIFF
--- a/styles/palette.css
+++ b/styles/palette.css
@@ -22,7 +22,8 @@
   --stanford-stone-dark-rgb: 84, 73, 72;
   --stanford-illuminating-dark-rgb: 254, 197, 29;
   --stanford-illuminating-light-rgb: 255, 231, 129;
-  --stanford-fog-light: #f4f4f4;
+  --stanford-fog-light-rgb: 244, 244, 244;
+  --stanford-fog-light: rgb(var(--stanford-fog-light-rgb));
   --stanford-sky-dark: #016895;
   --stanford-sky-dark-rgb: 1, 104, 149;
 


### PR DESCRIPTION
This will allow setting:
```
--bs-secondary-rgb: var(--stanford-fog-light-rgb):
```
in bento.