### PR TITLE
Align the stacked logo to the left on large screens

### DIFF
--- a/footer/index.html
+++ b/footer/index.html
@@ -32,7 +32,7 @@
           <div class="row row-gap-3">
             <div
               id="sul-footer-img"
-              class="d-none d-md-flex d-lg-none d-xl-flex col-sm-12 col-lg-3 col-xl-3 d-flex align-items-start justify-content-center"
+              class="d-none d-md-flex d-lg-none d-xl-flex col-sm-12 col-lg-3 col-xl-3 d-flex align-items-start justify-content-lg-start justify-content-md-center"
             >
               <a
                 href="https://library.stanford.edu"


### PR DESCRIPTION
Before
<img width="617" alt="Screenshot 2025-06-25 at 8 27 28 AM" src="https://github.com/user-attachments/assets/eb7fc379-4d67-426c-9b33-5067b262be38" />


After
<img width="557" alt="Screenshot 2025-06-25 at 8 27 08 AM" src="https://github.com/user-attachments/assets/3e5cade4-5a37-4933-bc8c-978bb4e15eef" />
