### PR TITLE
Define --bs-light-rgb and --bs-secondary-rgb

### DIFF
--- a/styles/colors.css
+++ b/styles/colors.css
@@ -15,7 +15,6 @@
   --bs-info-bg-subtle: rgba(var(--bs-info-rgb), 10%);
   --bs-info-border-subtle: rgb(var(--bs-info-rgb));
   --bs-info-text-emphasis: rgb(var(--bs-info-rgb));
-
   --bs-light-rgb: var(--stanford-fog-light-rgb);
   --bs-secondary-rgb: var(--stanford-cardinal-rgb);
 }


### PR DESCRIPTION
This allows us to use `.bg-light` and `.text-secondary` and get the correct colors.