### PR TITLE
Update link underlining for compatibility with Safari

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,10 @@
 {
   "extends": "stylelint-config-standard-scss",
   "rules": {
-    "color-function-notation": ["modern", { "ignore": ["with-var-inside"] }]
+    "color-function-notation": ["modern", { "ignore": ["with-var-inside"] }],
+    "property-no-vendor-prefix": [
+      true,
+      { "ignoreProperties": ["text-decoration"] }
+    ]
   }
 }

--- a/styles/links.css
+++ b/styles/links.css
@@ -22,7 +22,7 @@ a {
 
 .su-underline {
   --underline-color: var(--stanford-50-black);
-  --bs-link-decoration: underline dotted var(--underline-color) 1px;
+  --bs-link-decoration: underline dotted var(--underline-color);
   --bs-link-hover-color-rgb: var(--stanford-digital-blue-dark-rgb);
   --bs-link-hover-decoration: underline;
 }
@@ -31,6 +31,7 @@ a {
 a:not(.btn),
 .btn-link {
   text-decoration: var(--bs-link-decoration);
+  -webkit-text-decoration: var(--bs-link-decoration);
   text-underline-offset: 0.25rem;
 
   &:hover,


### PR DESCRIPTION
Safari doesn't support color + style in the shorthand without the -webkit prefix:

<img width="401" alt="Screenshot 2025-07-03 at 07 50 33" src="https://github.com/user-attachments/assets/ed5f7fe2-fb1e-4875-b9b8-593f8fcee8d2" />

and doesn't support thickness at all (but 1px is the default, so I'm not sure we need to specify it?)