### PR TITLE
update link offset to 0.2rem

### DIFF
--- a/styles/links.css
+++ b/styles/links.css
@@ -32,7 +32,7 @@ a:not(.btn),
 .btn-link {
   text-decoration: var(--bs-link-decoration);
   -webkit-text-decoration: var(--bs-link-decoration);
-  text-underline-offset: 0.25rem;
+  text-underline-offset: 0.2rem;
 
   &:hover,
   &:focus-visible {


### PR DESCRIPTION
sometimes the line offset is too large and causes the text decoration not to show up on wrapped text. This fixes the issue:

Before:
<img width="793" height="569" alt="Screenshot 2025-07-24 at 12 50 27 PM" src="https://github.com/user-attachments/assets/c80e8859-80ec-4ab7-8571-a1596d43184a" />

After:
<img width="818" height="774" alt="Screenshot 2025-07-24 at 12 50 45 PM" src="https://github.com/user-attachments/assets/6527379d-99e6-4cee-9b24-70112d35e012" />
