### PR TITLE
Add a color palette generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "start": "http-server",
-    "lint": "stylelint **/*.css"
+    "lint": "stylelint **/*.css",
+    "build:palette": "node ./scripts/generate-color-palette.js"
   },
   "devDependencies": {
     "http-server": "^14.1.1",

--- a/palette/index.html
+++ b/palette/index.html
@@ -1,0 +1,264 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Component Library Color Palette</title>
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+    integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7"
+    crossorigin="anonymous"
+  />
+  <link href="../styles/sul.css" rel="stylesheet" />
+  <style>
+    .swatch { width: 4rem; height: 4rem; border-radius: 0.5rem; }
+  </style>
+</head>
+<body class="bg-light p-5">
+  <div class="container p-3">
+    <h1 class="mb-4">Color Palette</h1>
+    <div class="row g-3">
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-cardinal-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-cardinal</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-cardinal-dark-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-cardinal-dark</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: #2e2d29;"></div>
+              <small class="font-monospace fw-bold">--stanford-black</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-90-black-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-90-black</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: #585754;"></div>
+              <small class="font-monospace fw-bold">--stanford-80-black</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: #6d6c69;"></div>
+              <small class="font-monospace fw-bold">--stanford-70-black</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: #767674;"></div>
+              <small class="font-monospace fw-bold">--stanford-60-black</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: #979694;"></div>
+              <small class="font-monospace fw-bold">--stanford-50-black</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: #ababa9;"></div>
+              <small class="font-monospace fw-bold">--stanford-40-black</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: #c0c0bf;"></div>
+              <small class="font-monospace fw-bold">--stanford-30-black</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: #d5d5d4;"></div>
+              <small class="font-monospace fw-bold">--stanford-20-black</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: #eaeaea;"></div>
+              <small class="font-monospace fw-bold">--stanford-10-black</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-palo-verde-light-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-palo-verde-light</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-bay-light-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-bay-light</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-sky-light-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-sky-light</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-sky-dark-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-sky-dark</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-poppy-light-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-poppy-light</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-poppy-dark-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-poppy-dark</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-archway-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-archway</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-stone-light-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-stone-light</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-fog-light-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-fog-light</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-digital-green-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-digital-green</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-digital-red-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-digital-red</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-digital-red-dark-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-digital-red-dark</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-digital-red-light-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-digital-red-light</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-digital-blue-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-digital-blue</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: rgb(var(--stanford-digital-blue-dark-rgb));"></div>
+              <small class="font-monospace fw-bold">--stanford-digital-blue-dark</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: color-mix(
+    in srgb,
+    var(--stanford-digital-red-dark) 90%,
+    black
+  );"></div>
+              <small class="font-monospace fw-bold">--stanford-digital-red-darker</small>
+            </div>
+          </div>
+        </div>
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: color-mix(
+    in srgb,
+    var(--stanford-digital-blue-dark) 90%,
+    black
+  );"></div>
+              <small class="font-monospace fw-bold">--stanford-digital-blue-darker</small>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/scripts/generate-color-palette.js
+++ b/scripts/generate-color-palette.js
@@ -1,0 +1,66 @@
+const fs = require('fs')
+const cssFile = './styles/palette.css'
+const outputFile = './palette/index.html'
+const cssContent = fs.readFileSync(cssFile, 'utf8');
+const colors = getColors(cssContent)
+const html = generateHTML(colors)
+
+try {
+  fs.writeFileSync(outputFile, html)
+  console.log(`Generated ${outputFile} with ${colors.length} colors`)
+} catch (error) {
+  console.error(`Error writing the palette HTML: ${error.message}`)
+  process.exit(1)
+}
+
+function getColors(css) {
+  const colors = []
+  const cssVariableRegex = /--([^:]+):\s*([^;]+);/g
+  let match
+
+  while ((match = cssVariableRegex.exec(css)) !== null) {
+    const colorName = `--${match[1].trim()}`
+    const colorValue = match[2].trim()
+    if (colorName.includes('-rgb') && !colorValue.startsWith('rgb(')) {
+      continue
+    }
+    colors.push({ name: colorName, value: colorValue })
+  }
+
+  return colors
+}
+
+function generateHTML(colors) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <title>Component Library Color Palette</title>
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+    integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7"
+    crossorigin="anonymous"
+  />
+  <link href="../styles/sul.css" rel="stylesheet" />
+  <style>
+    .swatch { width: 4rem; height: 4rem; border-radius: 0.5rem; }
+  </style>
+</head>
+<body class="bg-light p-5">
+  <div class="container p-3">
+    <h1 class="mb-4">Color Palette</h1>
+    <div class="row g-3">${colors.map(color => `
+      <div class="col-xl-4 col-md-6 col-sm-12">
+        <div class="card">
+          <div class="card-body d-flex align-items-center">
+            <div class="swatch me-3 border" style="background-color: ${color.value};"></div>
+              <small class="font-monospace fw-bold">${color.name}</small>
+            </div>
+          </div>
+        </div>`).join('')}
+      </div>
+    </div>
+  </div>
+</body>
+</html>`
+}


### PR DESCRIPTION
This is a little end-of-the-day riff after finding it surprisingly hard to verify a PR that changed/added colors. It adds a `build:palette` command to generate color palette HTML.

<img width="1159" height="246" alt="Screenshot 2025-07-29 at 5 52 33 PM" src="https://github.com/user-attachments/assets/8c036f2b-6825-4303-b788-b41e64fcbfbf" />


I don't think we really do this enough to justify having bespoke code, but I thought I'd push it up for a minute as a curiosity.