### PR TITLE
Add responsive design to rosette header example

### DIFF
--- a/header/light_variant.html
+++ b/header/light_variant.html
@@ -209,16 +209,18 @@
       <div class="masthead bg-light">
         <div class="container">
           <div
-            class="d-flex flex-wrap align-items-end justify-content-between pt-3 pb-1 pb-md-3 gap-2"
+            class="d-flex flex-wrap align-items-end pt-3 pb-1 pb-md-3 gap-2"
           >
-            <span class="rosette-logo me-1 align-self-start" aria-hidden></span>
-            <div class="me-1">
-              <div class="h1 my-0">
-                <a href="/">Application Title: Lorem ipsum</a>
+            <div class="d-flex align-items-end gap-2 flex-grow-1">
+              <span class="rosette-logo me-1 align-self-start flex-shrink-0" aria-hidden></span>
+              <div class="me-1 flex-grow-1">
+                <div class="h1 my-0">
+                  <a href="/">Application Title: Lorem ipsum</a>
+                </div>
+                <span class="h4 d-block my-1"
+                  >Application Subtitle: Lorem ipsum dolor sit amet</span
+                >
               </div>
-              <span class="h4 d-block my-1"
-                >Application Subtitle: Lorem ipsum dolor sit amet</span
-              >
             </div>
             <div class="navbars ms-md-auto">
               <nav


### PR DESCRIPTION
Changes the rosette header to more closely match the responsive design: https://www.figma.com/design/K1syTsalaB1nlRftgOi0Pw/DLSS-Components?node-id=1970-5776&t=GlBPU20logWdDm81-4

Driven by https://github.com/sul-dlss/SearchWorks/issues/5854