### PR TITLE
Show keyboard focus on navbar/pre-footer logo

### DIFF
--- a/styles/header.css
+++ b/styles/header.css
@@ -51,6 +51,16 @@
     background-position: 0 center;
   }
 
+  &:focus-visible,
+  &:focus-visible.polychrome {
+    --bs-navbar-brand-hover-color: var(--bs-nav-link-color);
+
+    background-color: unset;
+    background-image: none;
+    mask-image: none;
+    text-indent: unset;
+  }
+
   @media (width < 575.98px) {
     &.stacked-mobile {
       --sul-logo-width: 50%;


### PR DESCRIPTION
@dbranchini flagged the absence of the focus ring on the navbar & pre-footer logos in https://github.com/sul-dlss/SearchWorks/issues/5627.

One approach could be to remove the mask/background image when it has keyboard focus and show the text link with our standard focus ring styling.