### PR TITLE
Update the colors of warning and note alerts/banners

### DIFF
--- a/styles/alert.css
+++ b/styles/alert.css
@@ -18,9 +18,9 @@
 }
 
 .alert-note {
-  --bs-alert-bg: rgba(var(--stanford-illuminating-dark-rgb), 10%);
-  --bs-alert-color: rgb(var(--stanford-illuminating-dark-rgb));
-  --bs-alert-border-color: rgb(var(--stanford-illuminating-dark-rgb));
+  --bs-alert-bg: rgba(var(--stanford-plum-light-rgb), 10%);
+  --bs-alert-color: rgb(var(--stanford-plum-light-rgb));
+  --bs-alert-border-color: rgb(var(--stanford-plum-light-rgb));
 }
 
 .banner {

--- a/styles/colors.css
+++ b/styles/colors.css
@@ -7,7 +7,7 @@
   --bs-success-bg-subtle: rgba(var(--bs-success-rgb), 10%);
   --bs-success-border-subtle: rgb(var(--bs-success-rgb));
   --bs-success-text-emphasis: rgb(var(--bs-success-rgb));
-  --bs-warning-rgb: var(--stanford-poppy-rgb);
+  --bs-warning-rgb: var(--stanford-poppy-dark-rgb);
   --bs-warning-bg-subtle: rgba(var(--bs-warning-rgb), 10%);
   --bs-warning-border-subtle: rgb(var(--bs-warning-rgb));
   --bs-warning-text-emphasis: rgb(var(--bs-warning-rgb));

--- a/styles/palette.css
+++ b/styles/palette.css
@@ -36,6 +36,9 @@
   --stanford-sky-dark-rgb: 1, 104, 149;
   --stanford-sky-light: rgb(var(--stanford-sky-light-rgb));
   --stanford-sky-dark: rgb(var(--stanford-sky-dark-rgb));
+  --stanford-plum-rgb: 98, 0, 89;
+  --stanford-plum-light-rgb: 115, 70, 117;
+  --stanford-plum-dark-rgb: 53, 13, 54;
   --stanford-poppy-rgb: 233, 131, 0;
   --stanford-poppy-light-rgb: 249, 164, 74;
   --stanford-poppy-dark-rgb: 209, 102, 15;


### PR DESCRIPTION
Fixes #193 

Alerts:
<img width="1658" height="706" alt="Screenshot 2025-09-05 at 2 36 51 PM" src="https://github.com/user-attachments/assets/44bf06f5-584d-48f6-a38a-f26c48837038" />

Banners:

<img width="1646" height="719" alt="Screenshot 2025-09-05 at 2 36 43 PM" src="https://github.com/user-attachments/assets/50466be2-9119-4535-a3cf-339747ea7a03" />
