### PR TITLE
Change Stanford University focus ring to only include text

### DIFF
--- a/styles/header.css
+++ b/styles/header.css
@@ -17,7 +17,6 @@
   --bs-link-hover-decoration: none;
 
   color: var(--identity-bar-color);
-  display: block;
   font-size: 1.25rem;
   font-family: Stanford, var(--font-family-serif);
   font-weight: 400;


### PR DESCRIPTION
Currently, it includes the full width.

<img width="1477" height="210" alt="image" src="https://github.com/user-attachments/assets/4e68eeb4-f0db-4375-b5e5-158637c75b2a" />


closes #197