### PR TITLE
add background-size override for blacklight

### DIFF
--- a/styles/header.css
+++ b/styles/header.css
@@ -31,6 +31,7 @@
   background-image: url("StanfordLibraries-logo.svg");
   background-repeat: no-repeat;
   background-position: 0 center;
+  background-size: auto;
   width: var(--sul-logo-width);
   height: var(--sul-logo-height);
 


### PR DESCRIPTION
https://github.com/projectblacklight/blacklight/blob/main/app/assets/stylesheets/blacklight/_header.scss#L12 will make the logo too small for Earthworks and ArcLight