### PR TITLE
Remove heading level class overrides

### DIFF
--- a/alerts/alerts.html
+++ b/alerts/alerts.html
@@ -124,7 +124,7 @@
 
   </div>
 
-  <h2 class="h5 mt-5">Notes</h2>
+  <h2 class="mt-5">Notes</h2>
 
   <ul>
     <li>This alert style is often used within an application body to visually distinguish content to the user. In these cases, including the
@@ -136,7 +136,7 @@
       for more info.</li>
   </ul>
   <div class="d-flex align-items-baseline">
-    <h2 class="h5 mt-5">HTML</h2>
+    <h2 class="mt-5">HTML</h2>
     <button class="btn btn-primary ms-auto" data-copy-target="" onclick="copyHTML(event)">Copy</button>
   </div>
   <pre>

--- a/banners/index.html
+++ b/banners/index.html
@@ -12,7 +12,7 @@
   </head>
   <body class="p-5">
     <main class="container">
-      <h1 class="h3">Banners</h1>
+      <h1>Banners</h1>
       <div class="border rounded p-3 mt-5">
 
       <!-- Note Banner -->
@@ -26,7 +26,7 @@
             <div class="d-flex">
               <div class="p-3 flex-grow-1">
                 <div class="d-flex align-items-center gap-2">
-                  <h2 id="note-heading" class="h4 mb-0">Welcome, Jane Doe</h2>
+                  <h2 id="note-heading" class="mb-0">Welcome, Jane Doe</h2>
                   <div class="vr vr-lg bg-su-process-black-50"></div>
                   <span class="text-uppercase">
                     phd student
@@ -60,7 +60,7 @@
             <div class="d-flex">
               <div class="p-3 flex-grow-1">
                 <div class="d-flex align-items-center gap-2">
-                  <h2 id="success-heading" class="h4 mb-0">Welcome, Jane Doe</h2>
+                  <h2 id="success-heading" class="mb-0">Welcome, Jane Doe</h2>
                   <div class="vr vr-lg bg-su-process-black-50"></div>
                   <span class="text-uppercase">
                     phd student
@@ -95,7 +95,7 @@
             <div class="d-flex">
               <div class="p-3 flex-grow-1">
                 <div class="d-flex align-items-center gap-2">
-                  <h2 id="warning-heading" class="h4 mb-0">Welcome, Jane Doe</h2>
+                  <h2 id="warning-heading" class="mb-0">Welcome, Jane Doe</h2>
                   <div class="vr vr-lg bg-su-process-black-50"></div>
                   <span class="text-uppercase">
                     phd student
@@ -129,7 +129,7 @@
             <div class="d-flex">
               <div class="p-3 flex-grow-1">
                 <div class="d-flex align-items-center gap-2">
-                  <h2 id="info-heading" class="h4 mb-0">Welcome, Jane Doe</h2>
+                  <h2 id="info-heading" class="mb-0">Welcome, Jane Doe</h2>
                   <div class="vr vr-lg bg-su-process-black-50"></div>
                   <span class="text-uppercase">
                     phd student
@@ -164,7 +164,7 @@
             <div class="d-flex">
               <div class="p-3 flex-grow-1">
                 <div class="d-flex align-items-center gap-2">
-                  <h2 id="danger-heading" class="h4 mb-0">Welcome, Jane Doe</h2>
+                  <h2 id="danger-heading" class="mb-0">Welcome, Jane Doe</h2>
                   <div class="vr vr-lg bg-su-process-black-50"></div>
                   <span class="text-uppercase">
                     phd student

--- a/facets/bl9.html
+++ b/facets/bl9.html
@@ -18,7 +18,7 @@
           <section id="sidebar" aria-label="Limit your search" class="col-md-4">
             <div id="facets" class="facets sidenav facets-toggleable-md">
               <div class="facets-header">
-                <h2 class="facets-heading h4">Filters</h2>
+                <h2 class="facets-heading">Filters</h2>
                 <button class="btn btn-outline-secondary facet-toggle-button d-block d-lg-none" type="button" data-toggle="collapse" data-target="#facet-panel-collapse" data-bs-toggle="collapse" data-bs-target="#facet-panel-collapse" aria-controls="facet-panel-collapse" aria-expanded="false">
                   <span data-show-label="">Show facets</span>
                   <span data-hide-label="">Hide facets</span>
@@ -26,7 +26,7 @@
               </div>
               <div id="facet-panel-collapse" class="facets-collapse d-lg-block collapse accordion">
               <div class="accordion-item facet-limit blacklight-access_facet facet-limit-active">
-      <h3 class="accordion-header p-0 facet-field-heading h6" id="facet-access_facet-header">
+      <h3 class="accordion-header p-0 facet-field-heading" id="facet-access_facet-header">
         <button type="button" class="btn accordion-button " data-toggle="collapse" data-bs-toggle="collapse" data-target="#facet-access_facet" data-bs-target="#facet-access_facet" aria-expanded="true" aria-controls="facet-access_facet">
               Access
 
@@ -47,7 +47,7 @@
       </div>
     </div>
             <div class="accordion-item facet-limit blacklight-format_main_ssim ">
-              <h3 class="accordion-header p-0 facet-field-heading h6" id="facet-format_main_ssim-header">
+              <h3 class="accordion-header p-0 facet-field-heading" id="facet-format_main_ssim-header">
                 <button type="button" class="btn accordion-button collapsed" data-toggle="collapse" data-bs-toggle="collapse" data-target="#facet-format_main_ssim" data-bs-target="#facet-format_main_ssim" aria-expanded="false" aria-controls="facet-format_main_ssim">
                       Resource type
 
@@ -65,7 +65,7 @@
               </div>
             </div>
             <div class="accordion-item facet-limit blacklight-format_physical_ssim ">
-              <h3 class="accordion-header p-0 facet-field-heading h6" id="facet-format_physical_ssim-header">
+              <h3 class="accordion-header p-0 facet-field-heading" id="facet-format_physical_ssim-header">
                 <button type="button" class="btn accordion-button collapsed" data-toggle="collapse" data-bs-toggle="collapse" data-target="#facet-format_physical_ssim" data-bs-target="#facet-format_physical_ssim" aria-expanded="false" aria-controls="facet-format_physical_ssim">
                       Media type
 

--- a/facets/index.html
+++ b/facets/index.html
@@ -124,7 +124,7 @@
   </head>
   <body>
     <main class="container">
-      <h1 class="h3 ">Blacklight 8 Facets</h1>
+      <h1>Blacklight 8 Facets</h1>
       <div class="mx-5"><a href="bl9">Blacklight 9 Facets</a></div>
       <div class="border rounded p-3 mt-5">
       <div class="row">

--- a/footer/index.html
+++ b/footer/index.html
@@ -14,7 +14,7 @@
   </head>
   <body>
     <main class="container">
-      <h1 class="h3">Footer</h1>
+      <h1>Footer</h1>
       <div class="border rounded p-3 mt-5">
         <footer data-html-target="footer">
           <section id="pre-footer" class="py-4" aria-label="Library footer">
@@ -210,7 +210,7 @@
         </footer>
       </div>
 
-      <h2 class="h5 mt-5">Notes</h2>
+      <h2 class="mt-5">Notes</h2>
       <ul>
         <li>You can set the <code>container</code> class on the pre-footer, to <code>container-lg</code> if the page content also uses container-lg (such as searchworks)</li>
       </ul>

--- a/header/index.html
+++ b/header/index.html
@@ -74,7 +74,7 @@
         <li>You can set the <code>container</code> class on the identity bar, navbar and masthead, to <code>container-lg</code> if the page content also uses container-lg (such as searchworks)</li>
       </ul>
       <div class="d-flex align-items-baseline">
-        <h2 class="h5 mt-5">HTML</h2>
+        <h2 class="mt-5">HTML</h2>
         <button class="btn btn-primary ms-auto" data-copy-target="" onclick="copyHTML(event)">Copy</button>
       </div>
       <pre>


### PR DESCRIPTION
With the recent typography updates, we no longer need to override the Bootstrap default font-sizes for heading levels (i.e., overriding `<h2 class="h4">`). This PR corrects instances where the overriden font-sizes now appear too small.

## Current
<img width="2922" height="982" alt="banners-current" src="https://github.com/user-attachments/assets/e001e9eb-395a-4351-a295-0620167abc60" />

## After
<img width="2922" height="982" alt="banners-after" src="https://github.com/user-attachments/assets/db7fdf07-d16c-4a20-8093-38c0de14ea07" />
