### PR TITLE
Update title and subtitle font-weights

### DIFF
--- a/header/dark_variant.html
+++ b/header/dark_variant.html
@@ -105,7 +105,7 @@
                 <span class="rosette-logo me-1 align-self-start flex-shrink-0" aria-hidden="true"></span>
                 <div class="me-1 flex-grow-1">
                   <div class="h1 my-0">
-                    <a href="/">Application Title: Lorem ipsum</a>
+                    <a href="/">Application Title</a>
                   </div>
                 </div>
               </div>

--- a/header/light_variant.html
+++ b/header/light_variant.html
@@ -102,11 +102,11 @@
                 <span class="rosette-logo me-1 align-self-start flex-shrink-0" aria-hidden="true"></span>
                 <div class="me-1 flex-grow-1">
                   <div class="h1 my-0">
-                    <a href="/">Application Title: Lorem ipsum</a>
+                    <a href="/">Application Title</a>
                   </div>
                   <span
-                    class="h4 d-block my-1"
-                  >Application Subtitle: Lorem ipsum dolor sit amet</span>
+                    class="fs-4 fw-light d-block my-1"
+                  >Optionally Include an Application Subtitle</span>
                 </div>
               </div>
               <div class="navbars ms-md-auto">

--- a/header/stacked_logo.html
+++ b/header/stacked_logo.html
@@ -101,10 +101,10 @@
                 <span class="rosette-logo me-1 align-self-start flex-shrink-0" aria-hidden="true"></span>
                 <div class="me-1 flex-grow-1">
                   <div class="h1 my-0">
-                    <a href="/">Application Title: Lorem ipsum</a>
+                    <a href="/">Application Title</a>
                   </div>
-                  <span class="h4 d-block my-1"
-                    >Application Subtitle: Lorem ipsum dolor sit amet</span
+                  <span class="fs-4 fw-light d-block my-1"
+                    >Optionally Include an Application Subtitle</span
                   >
                 </div>
               </div>

--- a/header/white_variant.html
+++ b/header/white_variant.html
@@ -101,10 +101,10 @@
                 <span class="rosette-logo me-1 align-self-start flex-shrink-0" aria-hidden="true"></span>
                 <div class="me-1 flex-grow-1">
                   <div class="h1 my-0">
-                    <a href="/">Application Title: Lorem ipsum</a>
+                    <a href="/">Application Title</a>
                   </div>
-                  <span class="h4 d-block my-1"
-                    >Application Subtitle: Lorem ipsum dolor sit amet</span
+                  <span class="fs-4 fw-light d-block my-1"
+                    >Optionally Include an Application Subtitle</span
                   >
                 </div>
               </div>

--- a/styles/header.css
+++ b/styles/header.css
@@ -193,6 +193,8 @@
     font-size: 2.25rem;
 
     a {
+      font-weight: 500;
+
       --bs-link-hover-decoration: none;
     }
   }


### PR DESCRIPTION
- Fixes issue with subtitle font-size, which currently appears too small after typography updates.
- Small revisions to title and subtitle font-weights. [Figma design](https://www.figma.com/design/K1syTsalaB1nlRftgOi0Pw/DLSS-Components?node-id=742-922&t=bQCnKdhhLyQCT4V0-4)

## Current
<img width="2922" height="496" alt="app-title-font-weight-current" src="https://github.com/user-attachments/assets/4686006f-680c-4590-9c77-207fbe23a569" />

## After
<img width="2922" height="518" alt="app-title-font-weight-after" src="https://github.com/user-attachments/assets/da323edf-c239-424d-b3e9-db7d547ffb08" />