### PR TITLE
move header overrides into class

### DIFF
--- a/header/light_variant.html
+++ b/header/light_variant.html
@@ -5,11 +5,6 @@
       @layer framework, component;
       @import url(https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css) layer(framework);
       @import url(../styles/sul.css) layer(component);
-
-      :root {
-        --identity-bar-bg-color: var(--stanford-cardinal);
-        --identity-bar-color: white;
-      }
     </style>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
@@ -41,7 +36,7 @@
         </div>
       </nav>
       <header>
-        <div class="identity-bar">
+        <div class="identity-bar identity-bar-dark">
           <div class="container">
             <a
               class="su-brand-bar__logo"

--- a/header/stacked_logo.html
+++ b/header/stacked_logo.html
@@ -5,11 +5,6 @@
       @layer framework, component;
       @import url(https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css) layer(framework);
       @import url(../styles/sul.css) layer(component);
-
-      :root {
-        --identity-bar-bg-color: var(--stanford-cardinal);
-        --identity-bar-color: white;
-      }
     </style>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
@@ -40,7 +35,7 @@
       </div>
     </nav>
     <header>
-      <div class="identity-bar">
+      <div class="identity-bar identity-bar-dark">
         <div class="container">
           <a
             class="su-brand-bar__logo"

--- a/header/white_variant.html
+++ b/header/white_variant.html
@@ -5,11 +5,6 @@
       @layer framework, component;
       @import url(https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css) layer(framework);
       @import url(../styles/sul.css) layer(component);
-
-      :root {
-        --identity-bar-bg-color: var(--stanford-cardinal);
-        --identity-bar-color: white;
-      }
     </style>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
@@ -41,7 +36,7 @@
         </div>
       </nav>
       <header>
-        <div class="identity-bar">
+        <div class="identity-bar identity-bar-dark">
           <div class="container">
             <a
               class="su-brand-bar__logo"

--- a/styles/header.css
+++ b/styles/header.css
@@ -7,6 +7,11 @@
   background-color: var(--identity-bar-bg-color);
 }
 
+.identity-bar-dark {
+  --identity-bar-bg-color: var(--stanford-cardinal);
+  --identity-bar-color: white;
+}
+
 /* stylelint-disable selector-class-pattern */
 .su-brand-bar__logo {
   --bs-link-hover-decoration: none;


### PR DESCRIPTION
We are doing this override in at least 7 other places. It would be nice if we didn't have to.

https://github.com/search?q=org%3Asul-dlss++-repo%3Asul-dlss%2Fcomponent-library+--identity-bar-color&type=code